### PR TITLE
Script fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,12 @@ CACHE_ADDRESSES=$(CUSTODIANS:%=cache/address/%.tsv)
 $(CACHE_STREETS):	cache/street/.touched
 $(CACHE_ADDRESSES):	cache/address/.touched
 
-cache/street/.touched:	bin/tsvcat bin/tsvsplit $(GRID_STREETS)
+cache/street/.touched:	bin/tsvcat.sh bin/tsvsplit $(GRID_STREETS)
 	mkdir -p cache/street
 	bin/tsvcat.sh cache/grid/street | cut -d'	' -f2- | bin/tsvsplit cache/street/ .tsv street-custodian
 	touch $@
 
-cache/address/.touched:	bin/tsvcat bin/tsvsplit $(GRID_ADDRESSES)
+cache/address/.touched:	bin/tsvcat.sh bin/tsvsplit $(GRID_ADDRESSES)
 	mkdir -p cache/address
 	bin/tsvcat.sh cache/grid/address | cut -d'	' -f2- | bin/tsvsplit cache/address/ .tsv street-custodian
 	touch $@

--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ The data can be ordered using the session-based shopping cart system. We have no
 
 ### Downloading
 
-Use make to download the AddressBase CSV files in the `cache/AddressBase` directory:
+Use make to download the AddressBase CSV files in the `cache/AddressBase` directory,
+if you have an old download then remove `cache/AddressBase` first:
 
+    $ rm -rf ./cache/AddressBase
     $ make download
 
 ### Building

--- a/bin/download.sh
+++ b/bin/download.sh
@@ -8,5 +8,5 @@ file=$(basename "$out")
 
 grep '<li>' |
   grep $file |
-  sed -e 's/^.*<a href="//' -e 's/">Add.*$//' -e 's/&amp;/\&/g' |
+  sed -e "s/^.*<a href=[\"|']//" -e "s/[\"|']>Add.*$//" -e 's/&amp;/\&/g' |
       xargs curl -s  > "$out"

--- a/bin/download.sh
+++ b/bin/download.sh
@@ -6,7 +6,11 @@
 out="$1"
 file=$(basename "$out")
 
-grep '<li>' |
-  grep $file |
-  sed -e "s/^.*<a href=[\"|']//" -e "s/[\"|']>Add.*$//" -e 's/&amp;/\&/g' |
-      xargs curl -s  > "$out"
+if [[ -e $out ]]; then
+  echo "exists: $out";
+else
+  grep '<li>' |
+    grep $file |
+    sed -e "s/^.*<a href=[\"|']//" -e "s/[\"|']>Add.*$//" -e 's/&amp;/\&/g' |
+        xargs curl -s  > "$out";
+fi


### PR DESCRIPTION
- Correct name of a script file in makefile.
- Handle single quoted href attributes in download script.
- Change to not download file when file already exists.
- Add remove old download step to readme.